### PR TITLE
fix(llm-blueprint): include reasoning tokens in output tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ Every LLM API call automatically sends this data to Dodo Payments:
 }
 ```
 
+**Note:** For models with reasoning capabilities, `outputTokens` automatically includes both completion tokens and reasoning tokens.
+
 ---
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -381,8 +381,7 @@ Every LLM API call automatically sends this data to Dodo Payments:
     "inputTokens": 10,
     "outputTokens": 25, 
     "totalTokens": 35,
-    "model": "gpt-4",
-    "provider": "openai"
+    "model": "gpt-4"
   }
 }
 ```

--- a/examples/ai-sdk-example.ts
+++ b/examples/ai-sdk-example.ts
@@ -19,16 +19,13 @@ async function aiSdkExample() {
       client: { generateText },
       customerId: "customer_123",
       metadata: {
-        model: "gemini-2.0-flash",
-        feature: "chat",
-        userTier: "premium",
-        sessionId: "sess_456",
+        provider: "ai-sdk",
       },
     });
 
     // 3. Use the wrapped function
     const response = await client.generateText({
-      model: google("gemini-2.0-flash"),
+      model: google("gemini-2.5-flash"),
       prompt: "Hello, I am a cool guy! Tell me a fun fact.",
       maxOutputTokens: 500,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dodopayments/ingestion-blueprints",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dodopayments/ingestion-blueprints",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "dodopayments": "^2.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dodopayments/ingestion-blueprints",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dodopayments/ingestion-blueprints",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "dodopayments": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodopayments/ingestion-blueprints",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Sophisticated Dodo Payments Ingestion Blueprints",
   "main": "./dist/index.cjs",

--- a/src/blueprints/llm/tracker.ts
+++ b/src/blueprints/llm/tracker.ts
@@ -81,8 +81,11 @@ export class LLMTracker {
     if (response?.usageMetadata) {
       const usage = response.usageMetadata;
       const inputTokens = usage.promptTokenCount || 0;
-      const outputTokens = usage.candidatesTokenCount || 0;
+      const candidatesTokens = usage.candidatesTokenCount || 0;
+      const thoughtsTokens = usage.thoughtsTokenCount || 0;
+      const outputTokens = candidatesTokens + thoughtsTokens;
       const totalTokens = usage.totalTokenCount || (inputTokens + outputTokens);
+      
       return {
         inputTokens,
         outputTokens,
@@ -116,7 +119,9 @@ export class LLMTracker {
     // AI SDK format
     else if (usage.inputTokens !== undefined) {
       inputTokens = usage.inputTokens || 0;
-      outputTokens = usage.outputTokens || 0;
+      const baseOutputTokens = usage.outputTokens || 0;
+      const reasoningTokens = usage.reasoningTokens || 0;
+      outputTokens = baseOutputTokens + reasoningTokens;
       totalTokens = usage.totalTokens || (inputTokens + outputTokens);
     }
     // Generic format


### PR DESCRIPTION
## Description
Improved outputTokens accuracy by including reasoning tokens for AI SDK and Google Genai

## Related Issue
Fixes #(issue number)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made
- Updated the LLM tracker logic to ensure reasoning tokens are included in outputTokens for AI SDK and Google Gemini providers, improving accuracy of token usage reporting.
- Clarified documentation in README.md to state that outputTokens now automatically includes both completion tokens and reasoning tokens for models with reasoning capabilities.
- Bumped package version to 0.3.0.

## Testing
- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Code Quality
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

## Additional Notes
Add any additional notes about the changes here.

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Checklist
- [x] I have read and followed the contributing guidelines
- [x] My code is properly formatted
- [x] I have updated the documentation as needed
- [ ] I have added appropriate tests
- [ ] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Token analytics now include reasoning tokens in output counts for supported providers, improving accuracy of usage metrics.

* Documentation
  * Clarified that outputTokens include both completion and reasoning tokens for reasoning-capable models.
  * Updated tracking example to remove the provider field from event metadata.
  * Refreshed example configuration to reflect current model usage and metadata format.

* Chores
  * Bumped version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->